### PR TITLE
Fixed a bug with installing opendkim

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -17,6 +17,8 @@
 
 echo "Installing programs..."
 apt install postfix dovecot-imapd opendkim spamassassin spamc
+# Install another requirement for opendikm only if the above command didn't get it already
+[ -e $(which opendkim-genkey) ] || apt install opendkim-tools
 domain="$(cat /etc/mailname)"
 subdom="mail"
 maildomain="$subdom.$domain"


### PR DESCRIPTION
The main command for generating DKIM keys (`opendkim-genkey`) wasn't installed with just the `opendkim` package.  Added a fix so it would be installed should it not be there the first time `apt` is ran.